### PR TITLE
[Perf] Better move ordering

### DIFF
--- a/ChessBot.Tests/StateTests.cs
+++ b/ChessBot.Tests/StateTests.cs
@@ -281,6 +281,7 @@ namespace ChessBot.Tests
             });
         }
         
+        // todo: add stress test for GetMoves
         // todo: add castling tests for GetMoves
 
         [Fact]

--- a/ChessBot/MutState.cs
+++ b/ChessBot/MutState.cs
@@ -5,7 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
-using System.Text;
+using System.Runtime.Serialization;
 using static ChessBot.StaticInfo;
 using static ChessBot.Types.File;
 using static ChessBot.Types.Rank;
@@ -120,83 +120,164 @@ namespace ChessBot
             // because this method is lazy (ie. uses iterators) and our state is mutable, we have to make a copy of all of the relevant state variables
             return GetPseudoLegalMoves(
                 Board,
+                _bbs,
                 ActiveSide,
                 EnPassantTarget,
-                ActivePlayer.Occupies,
-                OpposingPlayer.Occupies,
                 CanReallyCastleKingside,
                 CanReallyCastleQueenside);
         }
 
         private static IEnumerable<Move> GetPseudoLegalMoves(
             Board board,
+            Bitboards bbs,
             Side activeSide,
             Location? enPassantTarget,
-            Bitboard activeOccupies,
-            Bitboard opposingOccupies,
             bool canReallyCastleKingside,
             bool canReallyCastleQueenside)
         {
-            Bitboard occupied = activeOccupies | opposingOccupies;
+            // We attempt to return "better" moves (ie. ones that are more likely to cause cutoffs) first.
+            // Captures are returned first, then non-captures. (todo: give promotions priority within non-captures)
+            // Captures are ordered according to MVV-LVA. Non-captures will be ordered according to the history heuristic (todo).
 
-            /// <summary>
-            /// Returns a list of locations that the piece at <paramref name="source"/> may move to.
-            /// Does not account for whether the move would be invalid because its king is currently in check.
-            /// </summary>
-            Bitboard GetPseudoLegalDestinations(Location source)
+            // workarounds for unsafe code not being allowed in iterator blocks
+            unsafe static Bitboard GetPiecePlacement(in Bitboards bbs, Piece piece)
+            {
+                Debug.Assert(piece.IsValid);
+                return bbs.PiecePlacement[piece.ToIndex()];
+            }
+            unsafe static Bitboard GetOccupies(in Bitboards bbs, Side side)
+            {
+                Debug.Assert(side.IsValid());
+                return bbs.Occupies[(int)side];
+            }
+            unsafe static Bitboard GetAttacks(in Bitboards bbs, Side side)
+            {
+                Debug.Assert(side.IsValid());
+                return bbs.Attacks[(int)side];
+            }
+
+            var opposingSide = activeSide.Flip();
+            Bitboard occupied = GetOccupies(in bbs, Side.White) | GetOccupies(in bbs, Side.Black);
+
+            // Captures
+
+            // Loop over all pieces that can be captured, from most to least valuable
+            for (var victimKind = PieceKind.Queen; victimKind >= PieceKind.Pawn; victimKind--)
+            {
+                var victim = new Piece(opposingSide, victimKind);
+                for (var ds = GetPiecePlacement(in bbs, victim); ds != Bitboard.Zero; ds = ds.ClearLsb())
+                {
+                    var destination = ds.NextLocation();
+                    Debug.Assert(board[destination].HasPiece && board[destination].Piece == victim);
+
+                    // Loop over all pieces that can capture at `destination`, from least to most valuable
+                    if (GetAttacks(in bbs, activeSide)[destination])
+                    {
+                        for (var aggKind = PieceKind.Pawn; aggKind <= PieceKind.King; aggKind++)
+                        {
+                            var agg = new Piece(activeSide, aggKind);
+                            for (var ss = GetPiecePlacement(in bbs, agg); ss != Bitboard.Zero; ss = ss.ClearLsb())
+                            {
+                                var source = ss.NextLocation();
+                                Debug.Assert(board[source].HasPiece && board[source].Piece == agg);
+
+                                var sourceAttacks = GetModifiedAttackBitboard(source, board[source].Piece, occupied);
+                                if (sourceAttacks[destination])
+                                {
+                                    bool isPromotion = (aggKind == PieceKind.Pawn && source.Rank == SeventhRank(activeSide));
+                                    if (isPromotion)
+                                    {
+                                        yield return new Move(source, destination, promotionKind: PieceKind.Knight);
+                                        yield return new Move(source, destination, promotionKind: PieceKind.Bishop);
+                                        yield return new Move(source, destination, promotionKind: PieceKind.Rook);
+                                        yield return new Move(source, destination, promotionKind: PieceKind.Queen);
+                                    }
+                                    else
+                                    {
+                                        yield return new Move(source, destination);
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    // En passant captures need to be handled specially
+                    if (enPassantTarget is Location epTarget)
+                    {
+                        bool canBeCapturedEp = (destination == epTarget.Up(ForwardStep(opposingSide)));
+                        if (canBeCapturedEp)
+                        {
+                            Debug.Assert(victimKind == PieceKind.Pawn);
+
+                            var pawnPlacement = GetPiecePlacement(in bbs, new Piece(activeSide, PieceKind.Pawn));
+                            if (destination.File > FileA && pawnPlacement[destination.Left(1)])
+                            {
+                                yield return new Move(destination.Left(1), epTarget);
+                            }
+                            if (destination.File < FileH && pawnPlacement[destination.Right(1)])
+                            {
+                                yield return new Move(destination.Right(1), epTarget);
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Non-captures
+
+            Bitboard GetNonCaptureDestinations(Location source)
             {
                 Debug.Assert(board[source].HasPiece);
                 Debug.Assert(board[source].Piece.Side == activeSide);
 
-                var piece = board[source].Piece;
-                var result = GetModifiedAttackBitboard(source, piece, occupied);
+                var result = Bitboard.Zero;
 
-                var side = piece.Side;
+                var piece = board[source].Piece;
+                var (side, kind) = (piece.Side, piece.Kind);
                 Debug.Assert(side == activeSide); // this assumption is only used when we check for castling availability
 
-                result &= ~activeOccupies; // we can't move to squares occupied by our own pieces
-
-                switch (piece.Kind)
+                // don't bother with attack vectors for pawns. they're totally unrelated to where the pawn can move without capturing.
+                if (kind == PieceKind.Pawn)
                 {
-                    case PieceKind.Pawn:
-                        // a pawn can only move to the left/right if it captures an opposing piece
-                        var captureMask = opposingOccupies;
-                        if (enPassantTarget.HasValue) captureMask |= enPassantTarget.Value.GetMask();
-                        result &= captureMask;
+                    Debug.Assert(source.Rank != EighthRank(side)); // pawns should be promoted once they reach the eighth rank, so Up() should be safe
 
-                        // the attack vectors also don't include moving forward by 1/2, so OR those in
-                        Debug.Assert(source.Rank != EighthRank(side)); // pawns should be promoted once they reach the eighth rank
-                        var forward = ForwardStep(side);
-                        var up1 = source.Up(forward);
-                        if (!occupied[up1])
+                    var forward = ForwardStep(side);
+                    var up1 = source.Up(forward);
+                    if (!occupied[up1])
+                    {
+                        result |= up1.GetMask();
+                        if (source.Rank == SecondRank(side))
                         {
-                            result |= up1.GetMask();
-                            if (source.Rank == SecondRank(side))
-                            {
-                                var up2 = source.Up(forward * 2);
-                                if (!occupied[up2]) result |= up2.GetMask();
-                            }
+                            var up2 = source.Up(forward * 2);
+                            if (!occupied[up2]) result |= up2.GetMask();
                         }
-                        break;
-                    case PieceKind.King:
-                        if (canReallyCastleKingside) result |= source.Right(2).GetMask();
-                        if (canReallyCastleQueenside) result |= source.Left(2).GetMask();
-                        break;
+                    }
+                    return result;
+                }
+
+                result = GetModifiedAttackBitboard(source, piece, occupied);
+                // we can't move to squares occupied by our own pieces, so exclude those.
+                // since we already dealt with captures, exclude squares that are occupied by opposing pieces.
+                result &= ~occupied;
+                if (kind == PieceKind.King)
+                {
+                    if (canReallyCastleKingside) result |= source.Right(2).GetMask();
+                    if (canReallyCastleQueenside) result |= source.Left(2).GetMask();
                 }
 
                 return result;
             }
 
-            for (var ss = activeOccupies; ss != Bitboard.Zero; ss = ss.ClearLsb())
+            for (var ss = GetOccupies(in bbs, activeSide); ss != Bitboard.Zero; ss = ss.ClearLsb())
             {
                 var source = ss.NextLocation();
                 var piece = board[source].Piece;
 
-                for (var ds = GetPseudoLegalDestinations(source); ds != Bitboard.Zero; ds = ds.ClearLsb())
+                for (var ds = GetNonCaptureDestinations(source); ds != Bitboard.Zero; ds = ds.ClearLsb())
                 {
                     var destination = ds.NextLocation();
-                    // If we're a pawn moving to the back rank and promoting, there are multiple moves to consider
-                    if (piece.Kind == PieceKind.Pawn && source.Rank == SeventhRank(activeSide))
+                    bool isPromotion = (piece.Kind == PieceKind.Pawn && source.Rank == SeventhRank(activeSide));
+                    if (isPromotion)
                     {
                         yield return new Move(source, destination, promotionKind: PieceKind.Knight);
                         yield return new Move(source, destination, promotionKind: PieceKind.Bishop);


### PR DESCRIPTION
We simply return capture moves before non-capture moves; this results in a nearly 50% speedup for all search algorithms. Captures are ordered according to MVV-LVA; in the future, non-captures will be ordered with the history heuristic.